### PR TITLE
Fix: Include *src* Directory in Package

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -2,7 +2,6 @@
 .vscode-test/**
 out/**
 node_modules/**
-src/**
 .gitignore
 .yarnrc
 webpack.config.js


### PR DESCRIPTION
This pull request resolves an issue where the package was not including files in the `src` directory, such as the JSON syntax highlighting rules. The issue was caused by the `src/**` entry in the `.vscodeignore` file, which excluded the directory during packaging.

## Changes Made
- Removed the `src/**` entry from the `.vscodeignore` file to ensure the `src` directory is included in the package.

## File Changes
- [`.vscodeignore`](diffhunk://#diff-0a721cd4753ff50bbbe1237397c3c7692080254fa766268fcc8b05ef633c50bfL5): Removed the `src` directory exclusion rule.

This change ensures that essential files for syntax highlighting and other functionality are correctly packaged.